### PR TITLE
Add toggler for songs with two tunes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,13 @@ Info came from this guide: https://www.joshmorony.com/deploying-capacitor-applic
 We will need it when we want to deploy to Google Play store.
 
 
-# iOS - TBD
+# iOS
+To run the app on iPhone follow these steps:
+
+1. Requires an IPhone and a Mac computer.
+2. Install XCode if you don't already have it (XCode only runs on Mac).
+    - Install cocoapods, and create a user to be a developer (don't need paid developer account yet)
+3. Navigate to the root directory of this project in Terminal.
+4. To open XCode with the project code, run `npx cap open ios`
+5. To update the iOS version with the latest web code, run `ionic capacitor sync`.
+6. Connect your iPhone to your computer, or with an simulator run the app.

--- a/src/components/SongViewer.css
+++ b/src/components/SongViewer.css
@@ -1,0 +1,14 @@
+ion-toggle {
+  --background: #73d2f8;
+  --handle-background: #1f96f8;
+
+  --background-checked: #73d2f8;
+  --handle-background-checked: #1f96f8;
+}
+
+#songTogglerDiv {
+    text-align: right;
+
+    margin-top: -40px;
+    margin-right: 20px;
+}

--- a/src/components/SongViewer.tsx
+++ b/src/components/SongViewer.tsx
@@ -1,11 +1,14 @@
-import React from 'react';
+import React, { useState } from 'react';
 import './SongViewer.css';
 import { makeThreeDigits } from '../utils/SongUtils';
+import { IonToggle } from '@ionic/react';
 
 const baseUrl = 'https://raw.githubusercontent.com/Church-Life-Apps/Resources/master/';
 const hymnalPart = 'SongsAndHymnsOfLife/SHL_'; // This part can change when red book is added
 const imageSuffix = '.png';
 const alt = 'No Song Found';
+
+const songsWithTwoTunes = [156, 216, 278, 478];
 
 // Props are kind of like the parameters for the constructor of this class.
 interface SongViewProps {
@@ -14,14 +17,30 @@ interface SongViewProps {
 
 /**
  * Song Viewer React Functional Component.
- * 
- * TODO: Handle songs with two tunes. Like SHL_156.
  */
 const SongViewer: React.FC<SongViewProps> = (props) => {
-  let url = baseUrl + hymnalPart + makeThreeDigits(props.songNumber) + imageSuffix;
+  const [secondTune, setSecondTune] = useState<boolean>(false);
 
-  // TODO: Add on click to the image to zoom in and out (potentially automatic on mobile though).
-  return <img src={url} alt={alt} />;
+  let songHasTwoTunes = songsWithTwoTunes.includes(props.songNumber);
+
+  let secondTuneSuffix = songHasTwoTunes && secondTune ? '-B' : '';
+
+  let url = baseUrl + hymnalPart + makeThreeDigits(props.songNumber) + secondTuneSuffix + imageSuffix;
+
+  // TODO: Add Pinch and Zoom to image.
+  return (
+    <div>
+      {/* Second Tune Toggler  */}
+      {songHasTwoTunes ? (
+        <div id="songTogglerDiv">
+          <IonToggle checked={secondTune} onIonChange={(e) => setSecondTune(!secondTune)}></IonToggle>
+        </div>
+      ) : null}
+
+      {/* image */}
+      <img src={url} alt={alt} />
+    </div>
+  );
 };
 
 export default SongViewer;


### PR DESCRIPTION
Added a toggler to toggle between songs with two tunes. There are only 4 songs with 2 tunes, so I just hard coded them into a list and check for them. When a song only has 1 tune, this toggler does not show up.

This is kind of a cool checkpoint because we will now be able to see all the content of the hymnal through the app.

<img width="364" alt="Screen Shot 2020-10-17 at 4 35 40 PM" src="https://user-images.githubusercontent.com/8559293/96353977-de8f3c80-1096-11eb-8a5a-f47a92c89df6.png">
<img width="368" alt="Screen Shot 2020-10-17 at 4 35 52 PM" src="https://user-images.githubusercontent.com/8559293/96353980-e0590000-1096-11eb-8987-473279cad6b6.png">

Also added to the readme for iOS. 

