### PR TITLE
Add build step to circleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,9 @@ jobs:
           paths:
             - ./node_modules
       - run:
+          name: Run build
+          command: npm run build
+      - run:
           name: Run tests
           command: npm run test
           


### PR DESCRIPTION
Adding 'npm run build' to continuous integration step. Expect this to fail right now until errors are resolved ([Pull Request #37]). Should pass after that gets checked in.