### PR TITLE
Update music view ui

### DIFF
--- a/src/components/Components.css
+++ b/src/components/Components.css
@@ -15,9 +15,7 @@ ion-toggle {
 
 #songTogglerDiv {
   text-align: right;
-
-  margin-top: -40px;
-  margin-right: 20px;
+  margin-bottom: -40px;
 }
 
 #musicViewDiv {

--- a/src/components/Components.css
+++ b/src/components/Components.css
@@ -20,6 +20,12 @@ ion-toggle {
   margin-right: 20px;
 }
 
+#musicViewDiv {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+
 /* Settings Pages */
 #feedbackResponseModal {
   padding: 15px;

--- a/src/components/MusicView.tsx
+++ b/src/components/MusicView.tsx
@@ -2,7 +2,6 @@ import React, { useState } from "react";
 import "./Components.css";
 import { makeThreeDigits } from "../utils/SongUtils";
 import { IonToggle } from "@ionic/react";
-import { TransformWrapper, TransformComponent } from "react-zoom-pan-pinch";
 
 const baseUrl = "https://raw.githubusercontent.com/Church-Life-Apps/Resources/master/";
 const hymnalPart = "SongsAndHymnsOfLife/SHL_"; // This part can change when red book is added

--- a/src/components/MusicView.tsx
+++ b/src/components/MusicView.tsx
@@ -33,18 +33,20 @@ const MusicView: React.FC<MusicViewProps> = (props) => {
 
   // TODO: Add Pinch and Zoom to image.
   return (
-    <div style={{ maxWidth: width }} id="musicViewDiv">
+    <div>
       {/* Second Tune Toggler  */}
-      {songHasTwoTunes ? (
+      {songHasTwoTunes && (
         <div id="songTogglerDiv">
           <IonToggle checked={secondTune} onIonChange={(e) => setSecondTune(!secondTune)}></IonToggle>
         </div>
-      ) : null}
+      )}
 
       {/* image */}
       {/* <TransformWrapper>
         <TransformComponent> */}
       <img
+        style={{ maxWidth: width }}
+        id="musicViewDiv"
         onDoubleClick={() => {
           if (zoomed) {
             setWidth(widthPixels);

--- a/src/components/MusicView.tsx
+++ b/src/components/MusicView.tsx
@@ -4,8 +4,7 @@ import { makeThreeDigits } from "../utils/SongUtils";
 import { IonToggle } from "@ionic/react";
 import { TransformWrapper, TransformComponent } from "react-zoom-pan-pinch";
 
-const baseUrl =
-  "https://raw.githubusercontent.com/Church-Life-Apps/Resources/master/";
+const baseUrl = "https://raw.githubusercontent.com/Church-Life-Apps/Resources/master/";
 const hymnalPart = "SongsAndHymnsOfLife/SHL_"; // This part can change when red book is added
 const imageSuffix = ".png";
 const alt = "No Song Found";
@@ -21,38 +20,42 @@ interface MusicViewProps {
  * Song Viewer React Functional Component.
  */
 const MusicView: React.FC<MusicViewProps> = (props) => {
+  const widthPixels = 700;
   const [secondTune, setSecondTune] = useState<boolean>(false);
+  const [width, setWidth] = useState<number>(widthPixels);
+  const [zoomed, setZoomed] = useState<boolean>(false);
 
   let songHasTwoTunes = songsWithTwoTunes.includes(props.songNumber);
 
   let secondTuneSuffix = songHasTwoTunes && secondTune ? "-B" : "";
 
-  let url =
-    baseUrl +
-    hymnalPart +
-    makeThreeDigits(props.songNumber) +
-    secondTuneSuffix +
-    imageSuffix;
+  let url = baseUrl + hymnalPart + makeThreeDigits(props.songNumber) + secondTuneSuffix + imageSuffix;
 
   // TODO: Add Pinch and Zoom to image.
   return (
-    <div>
+    <div style={{ maxWidth: width }} id="musicViewDiv">
       {/* Second Tune Toggler  */}
       {songHasTwoTunes ? (
         <div id="songTogglerDiv">
-          <IonToggle
-            checked={secondTune}
-            onIonChange={(e) => setSecondTune(!secondTune)}
-          ></IonToggle>
+          <IonToggle checked={secondTune} onIonChange={(e) => setSecondTune(!secondTune)}></IonToggle>
         </div>
       ) : null}
 
       {/* image */}
-      <TransformWrapper>
-        <TransformComponent>
-          <img src={url} alt={alt} />
-        </TransformComponent>
-      </TransformWrapper>
+      {/* <TransformWrapper>
+        <TransformComponent> */}
+      <img
+        onDoubleClick={() => {
+          if (zoomed) {
+            setWidth(widthPixels);
+          } else setWidth(widthPixels * 2);
+          setZoomed(!zoomed);
+        }}
+        src={url}
+        alt={alt}
+      />
+      {/* </TransformComponent>
+      </TransformWrapper> */}
     </div>
   );
 };


### PR DESCRIPTION
The image pinch-and zoom was a little funky on browser. I tried experimenting with the react-pinch-pan package but I couldn't figure a quick way to customize it.

I added a little double-click trigger on the image to "zoom in" and out on it based on image width. This is basically just for browser, mobile will lose the ability to zoom since images always take up the full width, but I think thats ok. Eventually we should look into the react-pinch-pan library and fine-tune it to our uses. for example - mouse wheel scroll should mean scroll up/down, not zoom in/out.

Leaving the react library there since we may still want to use it, or we could potentially create our own custom pinch/pan behavior.

@tobiola fyi

Also moved around the 2 tune toggler to the corner