### PR TITLE
Fix url nav error

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { BrowserRouter, Route, Switch } from "react-router-dom";
+import { HashRouter, Route, Switch } from "react-router-dom";
 
 /* Core CSS required for Ionic components to work properly */
 import "@ionic/react/css/core.css";
@@ -24,13 +24,13 @@ import BookPage from "./pages/BookPage";
 import SongPage from "./pages/SongPage";
 
 const App: React.FC = () => (
-  <BrowserRouter>
+  <HashRouter>
     <Switch>
       <Route path="/" component={HomePage} exact />
       <Route path="/:bookId" component={BookPage} exact />
       <Route path="/:bookId/:songId" component={SongPage} exact />
     </Switch>
-  </BrowserRouter>
+  </HashRouter>
 );
 
 export default App;


### PR DESCRIPTION
When deployed to gh pages, any path other than "/" returns a 404 error.
Ex: [https://church-life-apps/shl/303](https://church-life-apps/shl/303)

[Stack Overflow with Solution Options](https://stackoverflow.com/questions/46056414/getting-404-for-links-with-create-react-app-deployed-to-github-pages)

This PR has the easiest solution but possibly worth looking into other options.