### PR TITLE
Introduce lazy loading in the list view

### DIFF
--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -5,8 +5,10 @@ import {
   IonCardSubtitle,
   IonLabel,
   IonItem,
+  IonInfiniteScroll,
+  IonInfiniteScrollContent,
 } from "@ionic/react";
-import React from "react";
+import React, { useState } from "react";
 import { useParams, useHistory } from "react-router-dom";
 import { removePunctuation } from "../utils/SongUtils";
 import "./Components.css";
@@ -27,30 +29,66 @@ interface Song {
  */
 const SearchView: React.FC<SearchViewProps> = (props) => {
   const { bookId } = useParams<{ bookId: string }>();
+  const [songCards, setSongCards] = useState<JSX.Element[]>([]);
+  const [songCardsIterator] = useState(songs.songs.entries());
+
   let history = useHistory();
-
   let searchParam = GetSearchParam();
-  let searchIsEmpty = searchParam === undefined;
-  let searchIsNumber = typeof searchParam === "number";
 
-  let songCards: JSX.Element[];
-  if (searchIsEmpty) {
-    songCards = [];
-  } else if (searchIsNumber) {
-    songCards = [GenerateSongCard(songs.songs[(searchParam as number) - 1])];
+  if (typeof searchParam === "number") {
+    setSongCards([GenerateSongCard(songs.songs[(searchParam as number) - 1])]);
   } else {
-    songCards = songs.songs
-      .filter((s) => SongMatchesSearch(s, searchParam))
-      .map((s) => GenerateSongCard(s) as JSX.Element);
+    if (songCards.length === 0) {
+      LoadSongs(songCardsIterator, 20, searchParam as string[]);
+    }
   }
 
   return songCards.length > 0 ? (
-    <IonList>{songCards}</IonList>
+    <div>
+      <IonList>{songCards}</IonList>
+      <IonInfiniteScroll onIonInfinite={LoadMoreSongs}>
+        <IonInfiniteScrollContent
+          loadingSpinner="bubbles"
+          loadingText="Loading more songs..."
+        ></IonInfiniteScrollContent>
+      </IonInfiniteScroll>
+    </div>
   ) : (
     <IonItem>
       <IonLabel>No results found</IonLabel>
     </IonItem>
   );
+
+  function LoadMoreSongs(event: CustomEvent<void>) {
+    let target = event.target as HTMLIonInfiniteScrollElement;
+    if (!LoadSongs(songCardsIterator, 10, searchParam as string[])) {
+      target.disabled = true;
+    }
+    setSongCards(Array.from(songCards));
+    target.complete();
+  }
+
+  function LoadSongs(
+    songIterator: IterableIterator<[number, Song]>,
+    count: number,
+    searchParam: string[]
+  ): boolean {
+    while (count > 0) {
+      let nextSong = songIterator.next();
+      if (nextSong.done) {
+        return false;
+      }
+
+      let song = nextSong.value[1];
+
+      if (SongMatchesSearch(song, searchParam)) {
+        songCards.push(GenerateSongCard(song));
+        count--;
+      }
+    }
+
+    return true;
+  }
 
   function GetSearchParam() {
     if (
@@ -93,7 +131,11 @@ const SearchView: React.FC<SearchViewProps> = (props) => {
     );
   }
 
-  function SongMatchesSearch(song: Song, searchParam: any): boolean {
+  function SongMatchesSearch(song: Song, searchParam: string[]): boolean {
+    if (searchParam === undefined || searchParam.length === 0) {
+      return true;
+    }
+
     let title = removePunctuation(song.title.toLowerCase());
     let author = removePunctuation(song.author.toLowerCase());
 

--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -34,9 +34,10 @@ const SearchView: React.FC<SearchViewProps> = (props) => {
 
   let history = useHistory();
   let searchParam = GetSearchParam();
+  let searchIsNumber = typeof searchParam === "number";
 
-  if (typeof searchParam === "number") {
-    setSongCards([GenerateSongCard(songs.songs[(searchParam as number) - 1])]);
+  if (searchIsNumber) {
+    songCards.push(GenerateSongCard(songs.songs[(searchParam as number) - 1]));
   } else {
     if (songCards.length === 0) {
       LoadSongs(songCardsIterator, 20, searchParam as string[]);
@@ -46,7 +47,10 @@ const SearchView: React.FC<SearchViewProps> = (props) => {
   return songCards.length > 0 ? (
     <div>
       <IonList>{songCards}</IonList>
-      <IonInfiniteScroll onIonInfinite={LoadMoreSongs}>
+      <IonInfiniteScroll
+        onIonInfinite={LoadMoreSongs}
+        disabled={searchIsNumber}
+      >
         <IonInfiniteScrollContent
           loadingSpinner="bubbles"
           loadingText="Loading more songs..."

--- a/src/pages/BookPage.tsx
+++ b/src/pages/BookPage.tsx
@@ -21,9 +21,8 @@ const BookPage: React.FC = () => {
   const [searchString, setSearchString] = useState<string>();
 
   let history = useHistory();
-
-  let searchView = <SearchView searchString={searchString} />;
-  let searchBar = RenderSearchBar();
+  let searchBar = GetSearchBar();
+  let searchView = GetSearchView();
 
   return (
     <IonPage>
@@ -31,11 +30,13 @@ const BookPage: React.FC = () => {
         <NavigationBar backButtonOnClick={() => history.push("/")} />
       </IonHeader>
       <IonItem>{searchBar}</IonItem>
-      <IonContent>{searchView}</IonContent>
+
+      {/* The key here will trigger a re-initialization of a new searchView when it changes. */}
+      <IonContent key={searchString}>{searchView}</IonContent>
     </IonPage>
   );
 
-  function RenderSearchBar() {
+  function GetSearchBar() {
     return (
       <IonSearchbar
         type="search"
@@ -44,6 +45,10 @@ const BookPage: React.FC = () => {
         onIonChange={(e) => setSearchString(e.detail.value!.toString())}
       ></IonSearchbar>
     );
+  }
+
+  function GetSearchView() {
+    return <SearchView key={searchString} searchString={searchString} />;
   }
 };
 


### PR DESCRIPTION
- lazily load the list of songs using IonInfiniteScroll. We will only ever load 10-20 songs at a time. Should further improve performance.
- Revert to previous behavior: if no search terms entered, display full list of songs (lazily).