### PR TITLE
fix invisible search bar bug

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import "./theme/variables.css";
 import HomePage from "./pages/HomePage";
 import BookPage from "./pages/BookPage";
 import SongPage from "./pages/SongPage";
+import { DbManager } from "./database/DbManager";
 import { initGA, PageView } from "./tracking/GoogleAnalytics";
 import { logPlatforms } from "./utils/PlatformUtils";
 
@@ -35,6 +36,7 @@ try {
 export const AppName = "Hymnal App";
 
 const App: React.FC = () => {
+  DbManager.getInstance();
   logPlatforms();
 
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,6 @@ import "./theme/variables.css";
 import HomePage from "./pages/HomePage";
 import BookPage from "./pages/BookPage";
 import SongPage from "./pages/SongPage";
-import { DbManager } from "./database/DbManager";
 import { initGA, PageView } from "./tracking/GoogleAnalytics";
 import { logPlatforms } from "./utils/PlatformUtils";
 
@@ -36,8 +35,8 @@ try {
 export const AppName = "Hymnal App";
 
 const App: React.FC = () => {
-  DbManager.getInstance();
   logPlatforms();
+
   return (
     <HashRouter>
       <Switch>

--- a/src/database/DbManager.tsx
+++ b/src/database/DbManager.tsx
@@ -19,7 +19,7 @@ declare const window: { openDatabase: (arg0: string, arg1: string, arg2: string,
  * This class defines all the tables and instantiates them as a singleton database object when the app starts up.
  */
 export class DbManager {
-  private static instance: DbManager;
+  private static instance: DbManager = new DbManager();
   private songsTable: SQLiteObject | Database | undefined;
 
   /**
@@ -69,7 +69,7 @@ export class DbManager {
   }
 
   static isInitialized(): boolean {
-    return DbManager.instance !== undefined && DbManager.instance.getSongsTable !== undefined;
+    return DbManager.instance !== undefined && DbManager.instance.songsTable !== undefined;
   }
 
   static getInstance(): DbManager {

--- a/src/database/DbManager.tsx
+++ b/src/database/DbManager.tsx
@@ -19,7 +19,7 @@ declare const window: { openDatabase: (arg0: string, arg1: string, arg2: string,
  * This class defines all the tables and instantiates them as a singleton database object when the app starts up.
  */
 export class DbManager {
-  private static instance: DbManager = new DbManager();
+  private static instance: DbManager;
   private songsTable: SQLiteObject | Database | undefined;
 
   /**

--- a/src/pages/BookPage.tsx
+++ b/src/pages/BookPage.tsx
@@ -47,18 +47,17 @@ const BookPage: React.FC = () => {
       <IonHeader>
         <NavigationBar backButtonOnClick={() => history.push("/")} />
       </IonHeader>
-      {
-        DbManager.isInitialized() &&
-      <IonItem>
-        <IonInput
-          id="searchBar"
-          type="search"
-          value={searchString}
-          placeholder="Search for a song"
-          onIonChange={(word) => setSearchString(word.detail.value as string) }
-        ></IonInput>
-      </IonItem>
-      }
+      {DbManager.isInitialized() && (
+        <IonItem>
+          <IonInput
+            id="searchBar"
+            type="search"
+            value={searchString}
+            placeholder="Search for a song"
+            onIonChange={(word) => setSearchString(word.detail.value as string)}
+          ></IonInput>
+        </IonItem>
+      )}
       {/* The key here will trigger a re-initialization of a new searchView when it changes. */}
       <IonContent>
         <SearchView key={searchString + songs.length} songs={songs} />

--- a/src/pages/BookPage.tsx
+++ b/src/pages/BookPage.tsx
@@ -47,18 +47,18 @@ const BookPage: React.FC = () => {
       <IonHeader>
         <NavigationBar backButtonOnClick={() => history.push("/")} />
       </IonHeader>
+      {
+        DbManager.isInitialized() &&
       <IonItem>
         <IonInput
           id="searchBar"
           type="search"
           value={searchString}
           placeholder="Search for a song"
-          onIonChange={(word) => {
-            setSearchString(word.detail.value as string);
-          }}
-          hidden={!DbManager.isInitialized()}
+          onIonChange={(word) => setSearchString(word.detail.value as string) }
         ></IonInput>
       </IonItem>
+      }
       {/* The key here will trigger a re-initialization of a new searchView when it changes. */}
       <IonContent>
         <SearchView key={searchString + songs.length} songs={songs} />


### PR DESCRIPTION
I fiddled with props and re-rendering and state changes for awhile but then ended up with this. This is relatively clean and seems to just work. I tested it locally by adding dummy code to force DB initialization to take > 5 seconds. During that 5 seconds, the page is black and loading. Then when the page renders, it renders with the search bar _and_ the DB available. 

I still have some concern in the case when the DB fails to load completely. Then a user would just see the page with no search bar, which can be very confusing. I haven't seen this happen in my local env, but it could happen if there are networking or other issues.