### PR TITLE
Add fallback if DB does not load

### DIFF
--- a/src/components/LyricView.tsx
+++ b/src/components/LyricView.tsx
@@ -26,7 +26,11 @@ const LyricView: React.FC<LyricViewProps> = (props: LyricViewProps) => {
         fetchSongsAndPopulateSongsTable()
           .then((songs) => (songs ? songs : []))
           .then((songs) => songs[props.songNumber - 1])
-          .then((song) => new DbSong(props.songNumber, "", 0, 0, false, song.author, song.title, song.lyrics))
+          .then((song) =>
+            song
+              ? new DbSong(props.songNumber, "", 0, 0, false, song.author, song.title, JSON.stringify(song.lyrics))
+              : PLACEHOLDER_SONG
+          )
           .then((song) => setSong(song));
       }
     });

--- a/src/models/DbSong.tsx
+++ b/src/models/DbSong.tsx
@@ -48,5 +48,5 @@ export function sortDbSongs(songs: DbSong[], searchText: string): DbSong[] {
  * The title is much shorter by length, so matches in the title will naturally weigh more than matches in the lyrics.
  */
 function getMatchScore(song: DbSong, search: string) {
-  return getSimilarity(song.title, search) + getSimilarity(song.lyrics, search);
+  return getSimilarity(song.title, search) + getSimilarity(song.lyrics, search) + getSimilarity(song.author, search);
 }

--- a/src/test/App.test.tsx
+++ b/src/test/App.test.tsx
@@ -52,7 +52,7 @@ describe("App", () => {
   });
 
   it("searching author displays correct results", async () => {
-    await verifySearchResults(page, "chris tomlin", ["121. How Great Is Our God", "135. The Wonderful Cross"]);
+    await verifySearchResults(page, "bertha fennell", ["401. Savior, I By Faith Am Touching"], false);
   });
 
   it("searching is case and order insensitive", async () => {

--- a/src/utils/StringUtils.tsx
+++ b/src/utils/StringUtils.tsx
@@ -24,5 +24,5 @@ export function getSimilarity(word: string, search: string): number {
  * Returns true if a string is a number, false otherwise.
  */
 export function isNumeric(word: string): boolean {
-  return !isNaN(+word)
+  return !isNaN(+word);
 }

--- a/src/utils/StringUtils.tsx
+++ b/src/utils/StringUtils.tsx
@@ -17,5 +17,12 @@ const stringSimilarity = require("string-similarity"); // eslint-disable-line @t
  * 1 = the same string.
  */
 export function getSimilarity(word: string, search: string): number {
-  return stringSimilarity.compareTwoStrings(removePunctuation(word.toLowerCase()), search);
+  return stringSimilarity.compareTwoStrings(removePunctuation(word.toString().toLowerCase()), search);
+}
+
+/**
+ * Returns true if a string is a number, false otherwise.
+ */
+export function isNumeric(word: string): boolean {
+  return !isNaN(+word)
 }


### PR DESCRIPTION
The database doesn't load in everyone's browser, which kinda sucks, so after this, I will remove the database altogether from the app and replace it with less flaky things.

For now though, this is a quick fix to fall back to manual filter/sorting which will still allow people to use the app if the database never loads. Here is a screenshot of the database being purposely broken, but still getting search results back via the JSON text file.

![Screen Shot 2021-01-23 at 9 25 48 PM](https://user-images.githubusercontent.com/8559293/105620589-4787fe00-5dc4-11eb-911a-e438f36180d5.png)
