### PR TITLE
Add forward and back buttons to song page

### DIFF
--- a/src/components/Components.css
+++ b/src/components/Components.css
@@ -68,12 +68,7 @@ ion-modal {
 }
 
 /* something about icons being multiples of 8 pixels in width*/
-#prevButton {
-  --ionicon-stroke-width: 32px;
-  font-size: 72px;
-}
-
-#nextButton {
+.pageTurnButton {
   --ionicon-stroke-width: 32px;
   font-size: 72px;
 }

--- a/src/components/Components.css
+++ b/src/components/Components.css
@@ -67,9 +67,20 @@ ion-modal {
   padding-left: 0.5rem;
 }
 
-/* 
+/* something about icons being multiples of 8 pixels in width*/
+#prevButton {
+  --ionicon-stroke-width: 32px;
+  font-size: 72px;
+}
+
+#nextButton {
+  --ionicon-stroke-width: 32px;
+  font-size: 72px;
+}
+
+/*
 *  laptop/desktop sized devices are generally > 1200px.
-*    admittedly, this is arbitrary. A full responsive system 
+*    admittedly, this is arbitrary. A full responsive system
 *    might be better down the road
 */
 @media (min-width: 1200px) {

--- a/src/components/LyricView.tsx
+++ b/src/components/LyricView.tsx
@@ -26,14 +26,14 @@ interface LyricViewProps {
  */
 const LyricView: React.FC<LyricViewProps> = (props: LyricViewProps) => {
   const [song, setSong] = useState<Song>(PLACEHOLDER_SONG);
-  const { bookId } = useParams<{ bookId: string }>();
+  const { bookId, songId } = useParams<{ bookId: string, songId: string }>();
 
   useEffect(() => {
     triggerSongView(props.songNumber, SongViewMode.Lyrics);
     getSong(props.songNumber, bookId).then((song) => {
       setSong(song);
     });
-  }, []);
+  }, [songId]);
 
   return (
     <IonGrid>

--- a/src/components/LyricView.tsx
+++ b/src/components/LyricView.tsx
@@ -26,7 +26,7 @@ interface LyricViewProps {
  */
 const LyricView: React.FC<LyricViewProps> = (props: LyricViewProps) => {
   const [song, setSong] = useState<Song>(PLACEHOLDER_SONG);
-  const { bookId, songId } = useParams<{ bookId: string, songId: string }>();
+  const { bookId, songId } = useParams<{ bookId: string; songId: string }>();
 
   useEffect(() => {
     triggerSongView(props.songNumber, SongViewMode.Lyrics);

--- a/src/pages/SongPage.tsx
+++ b/src/pages/SongPage.tsx
@@ -22,7 +22,7 @@ const SongPage: React.FC = () => {
 
   // when in song view, use music view or lyrics view
   const [songViewMode, setSongViewMode] = useState<SongViewMode>(SongViewMode.Music);
-  console.log(history);
+
   return (
     <IonPage>
       <IonHeader>
@@ -36,9 +36,9 @@ const SongPage: React.FC = () => {
 
       <IonContent>
         {/* TODO: Add error handling in case of non number song Id */}
-        {isBrowser() && PrevButton(+songId)}
+        {isBrowser() && RenderPrevButton(+songId)}
         {RenderSong(+songId)}
-        {isBrowser() && NextButton(+songId)}
+        {isBrowser() && RenderNextButton(+songId)}
       </IonContent>
     </IonPage>
   );
@@ -64,7 +64,7 @@ const SongPage: React.FC = () => {
     }
   }
 
-  function PrevButton(songNumber: number) {
+  function RenderPrevButton(songNumber: number) {
     if (songNumber > 1) {
       return (
         <IonFab vertical="center" horizontal="start" slot="fixed">
@@ -81,7 +81,7 @@ const SongPage: React.FC = () => {
     }
   }
 
-  function NextButton(songNumber: number) {
+  function RenderNextButton(songNumber: number) {
     // idk how to get total number of songs so its hard coded for shl for now
     if (songNumber < 533) {
       return (

--- a/src/pages/SongPage.tsx
+++ b/src/pages/SongPage.tsx
@@ -1,10 +1,11 @@
-import { IonContent, IonPage, IonHeader } from "@ionic/react";
+import { IonIcon, IonContent, IonPage, IonHeader, IonFab, IonFabButton } from "@ionic/react";
 import { SongViewMode } from "../utils/SongUtils";
 import LyricView from "../components/LyricView";
 import MusicView from "../components/MusicView";
 import NavigationBar from "../components/NavigationBar";
 import React, { useState } from "react";
 import { useParams, useHistory } from "react-router-dom";
+import { arrowBackCircleOutline, arrowForwardCircleOutline } from "ionicons/icons";
 //Import Event tracking
 import { Event } from "../tracking/GoogleAnalytics";
 
@@ -20,7 +21,7 @@ const SongPage: React.FC = () => {
 
   // when in song view, use music view or lyrics view
   const [songViewMode, setSongViewMode] = useState<SongViewMode>(SongViewMode.Music);
-
+  console.log(history);
   return (
     <IonPage>
       <IonHeader>
@@ -34,7 +35,9 @@ const SongPage: React.FC = () => {
 
       <IonContent>
         {/* TODO: Add error handling in case of non number song Id */}
+        {PrevButton(+songId)}
         {RenderSong(+songId)}
+        {NextButton(+songId)}
       </IonContent>
     </IonPage>
   );
@@ -57,6 +60,35 @@ const SongPage: React.FC = () => {
       Event("INTERACTION", "Songmode is toggled", "SongMode_Toggle");
     } catch (e) {
       console.error(e);
+    }
+  }
+
+  function PrevButton(songNumber: number) {
+    if (songNumber > 1) {
+      return (
+        <IonFab vertical="center"horizontal="start" slot="fixed">
+          <IonFabButton color="medium" onClick={() => {
+          history.push(`/${bookId}/${songNumber - 1}`);
+        }}>
+            <IonIcon id="prevButton" icon={arrowBackCircleOutline} />
+          </IonFabButton>
+        </IonFab>
+      )
+    }
+  }
+
+  function NextButton(songNumber: number) {
+    // idk how to get total number of songs so its hard coded for shl for now
+    if (songNumber < 533) {
+      return (
+        <IonFab vertical="center" horizontal="end" slot="fixed">
+          <IonFabButton color="medium" onClick={() => {
+          history.push(`/${bookId}/${songNumber + 1}`);
+        }}>
+            <IonIcon id="nextButton" icon={arrowForwardCircleOutline} />
+          </IonFabButton>
+        </IonFab>
+      )
     }
   }
 };

--- a/src/pages/SongPage.tsx
+++ b/src/pages/SongPage.tsx
@@ -66,14 +66,17 @@ const SongPage: React.FC = () => {
   function PrevButton(songNumber: number) {
     if (songNumber > 1) {
       return (
-        <IonFab vertical="center"horizontal="start" slot="fixed">
-          <IonFabButton color="medium" onClick={() => {
-          history.push(`/${bookId}/${songNumber - 1}`);
-        }}>
+        <IonFab vertical="center" horizontal="start" slot="fixed">
+          <IonFabButton
+            color="medium"
+            onClick={() => {
+              history.push(`/${bookId}/${songNumber - 1}`);
+            }}
+          >
             <IonIcon id="prevButton" icon={arrowBackCircleOutline} />
           </IonFabButton>
         </IonFab>
-      )
+      );
     }
   }
 
@@ -82,13 +85,16 @@ const SongPage: React.FC = () => {
     if (songNumber < 533) {
       return (
         <IonFab vertical="center" horizontal="end" slot="fixed">
-          <IonFabButton color="medium" onClick={() => {
-          history.push(`/${bookId}/${songNumber + 1}`);
-        }}>
+          <IonFabButton
+            color="medium"
+            onClick={() => {
+              history.push(`/${bookId}/${songNumber + 1}`);
+            }}
+          >
             <IonIcon id="nextButton" icon={arrowForwardCircleOutline} />
           </IonFabButton>
         </IonFab>
-      )
+      );
     }
   }
 };

--- a/src/pages/SongPage.tsx
+++ b/src/pages/SongPage.tsx
@@ -72,7 +72,7 @@ const SongPage: React.FC = () => {
   function RenderPrevButton(songNumber: number) {
     if (songNumber > 1) {
       return (
-        <IonFab vertical="center" horizontal="start" slot="fixed">
+        <IonFab id="prevButton" vertical="center" horizontal="start" slot="fixed">
           <IonFabButton
             color="medium"
             onClick={() => {
@@ -90,7 +90,7 @@ const SongPage: React.FC = () => {
     // idk how to get total number of songs so its hard coded for shl for now
     if (songNumber < songBookLength) {
       return (
-        <IonFab vertical="center" horizontal="end" slot="fixed">
+        <IonFab id="nextButton" vertical="center" horizontal="end" slot="fixed">
           <IonFabButton
             color="medium"
             onClick={() => {

--- a/src/pages/SongPage.tsx
+++ b/src/pages/SongPage.tsx
@@ -4,11 +4,12 @@ import { isBrowser } from "../utils/PlatformUtils";
 import LyricView from "../components/LyricView";
 import MusicView from "../components/MusicView";
 import NavigationBar from "../components/NavigationBar";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useParams, useHistory } from "react-router-dom";
 import { arrowBackCircleOutline, arrowForwardCircleOutline } from "ionicons/icons";
 //Import Event tracking
 import { Event } from "../tracking/GoogleAnalytics";
+import { getNumSongsForBookId } from "../service/SongsService";
 
 /**
  * Song Page Component.
@@ -19,9 +20,15 @@ import { Event } from "../tracking/GoogleAnalytics";
 const SongPage: React.FC = () => {
   const { bookId, songId } = useParams<{ bookId: string; songId: string }>();
   const history = useHistory();
-
   // when in song view, use music view or lyrics view
   const [songViewMode, setSongViewMode] = useState<SongViewMode>(SongViewMode.Lyrics);
+  const [songBookLength, setSongBookLength] = useState<number>(0);
+
+  useEffect(() => {
+    getNumSongsForBookId(bookId).then((size) => 
+      setSongBookLength(size)
+    )
+  }, [bookId]);
 
   return (
     <IonPage>
@@ -83,7 +90,7 @@ const SongPage: React.FC = () => {
 
   function RenderNextButton(songNumber: number) {
     // idk how to get total number of songs so its hard coded for shl for now
-    if (songNumber < 533) {
+    if (songNumber < songBookLength) {
       return (
         <IonFab vertical="center" horizontal="end" slot="fixed">
           <IonFabButton

--- a/src/pages/SongPage.tsx
+++ b/src/pages/SongPage.tsx
@@ -25,9 +25,7 @@ const SongPage: React.FC = () => {
   const [songBookLength, setSongBookLength] = useState<number>(0);
 
   useEffect(() => {
-    getNumSongsForBookId(bookId).then((size) => 
-      setSongBookLength(size)
-    )
+    getNumSongsForBookId(bookId).then((size) => setSongBookLength(size));
   }, [bookId]);
 
   return (

--- a/src/pages/SongPage.tsx
+++ b/src/pages/SongPage.tsx
@@ -1,5 +1,6 @@
 import { IonIcon, IonContent, IonPage, IonHeader, IonFab, IonFabButton } from "@ionic/react";
 import { SongViewMode } from "../utils/SongUtils";
+import { isBrowser } from "../utils/PlatformUtils";
 import LyricView from "../components/LyricView";
 import MusicView from "../components/MusicView";
 import NavigationBar from "../components/NavigationBar";
@@ -35,9 +36,9 @@ const SongPage: React.FC = () => {
 
       <IonContent>
         {/* TODO: Add error handling in case of non number song Id */}
-        {PrevButton(+songId)}
+        {isBrowser() && PrevButton(+songId)}
         {RenderSong(+songId)}
-        {NextButton(+songId)}
+        {isBrowser() && NextButton(+songId)}
       </IonContent>
     </IonPage>
   );

--- a/src/pages/SongPage.tsx
+++ b/src/pages/SongPage.tsx
@@ -73,7 +73,7 @@ const SongPage: React.FC = () => {
               history.push(`/${bookId}/${songNumber - 1}`);
             }}
           >
-            <IonIcon id="prevButton" icon={arrowBackCircleOutline} />
+            <IonIcon class="pageTurnButton" icon={arrowBackCircleOutline} />
           </IonFabButton>
         </IonFab>
       );
@@ -91,7 +91,7 @@ const SongPage: React.FC = () => {
               history.push(`/${bookId}/${songNumber + 1}`);
             }}
           >
-            <IonIcon id="nextButton" icon={arrowForwardCircleOutline} />
+            <IonIcon class="pageTurnButton" icon={arrowForwardCircleOutline} />
           </IonFabButton>
         </IonFab>
       );

--- a/src/service/SongsService.tsx
+++ b/src/service/SongsService.tsx
@@ -38,6 +38,14 @@ async function getOrfetchSongs(bookId: string): Promise<Song[]> {
 }
 
 /**
+ * Gets number of songs in the songbook for bookId.
+ */
+export async function getNumSongsForBookId(bookId: string): Promise<number> {
+  const songs = await getOrfetchSongs(bookId);
+  return songs.length;
+}
+
+/**
  * Retrieves a single song based on song number.
  */
 export async function getSong(number: number, bookId: string): Promise<Song> {

--- a/src/test/App.test.tsx
+++ b/src/test/App.test.tsx
@@ -24,8 +24,8 @@ describe("App", () => {
 
   beforeAll(async () => {
     browser = await puppeteer.launch({
-      headless: false, // uncomment this to open browser window for tests
-      slowMo: 20, // use this to slow down testing for debugging purposes
+      // headless: false, // uncomment this to open browser window for tests
+      slowMo: 10, // use this to slow down testing for debugging purposes
       args: ["--no-sandbox", "--disable-setuid-sandbox"],
     });
   });

--- a/src/test/App.test.tsx
+++ b/src/test/App.test.tsx
@@ -15,7 +15,7 @@ const selectors = {
   lyricLine: "#lyricViewCard > ion-card-content > ion-text",
   noResultsFoundLabel: "#root > div > ion-content > ion-item > ion-label",
   nextButton: "#nextButton",
-  prevButton: "#prevButton"
+  prevButton: "#prevButton",
 };
 
 describe("App", () => {
@@ -181,10 +181,12 @@ describe("App", () => {
 
     await page.waitForSelector(selectors.nextButton);
     await page.click(selectors.nextButton);
-    
+
     expect(page.url()).toEqual(baseUrl + "/#/shl/7");
-    expect(await page.$eval(selectors.lyricViewIonCardTitle, (e) => e.innerHTML)).toEqual("God, Our Father, We Adore Thee!");
-    
+    expect(await page.$eval(selectors.lyricViewIonCardTitle, (e) => e.innerHTML)).toEqual(
+      "God, Our Father, We Adore Thee!"
+    );
+
     await page.waitForSelector(selectors.prevButton);
     await page.click(selectors.prevButton);
 

--- a/src/test/App.test.tsx
+++ b/src/test/App.test.tsx
@@ -14,6 +14,8 @@ const selectors = {
   songViewToggler: "#songViewToggler",
   lyricLine: "#lyricViewCard > ion-card-content > ion-text",
   noResultsFoundLabel: "#root > div > ion-content > ion-item > ion-label",
+  nextButton: "#nextButton",
+  prevButton: "#prevButton"
 };
 
 describe("App", () => {
@@ -22,8 +24,8 @@ describe("App", () => {
 
   beforeAll(async () => {
     browser = await puppeteer.launch({
-      // headless: false, // uncomment this to open browser window for tests
-      slowMo: 10, // use this to slow down testing for debugging purposes
+      headless: false, // uncomment this to open browser window for tests
+      slowMo: 20, // use this to slow down testing for debugging purposes
       args: ["--no-sandbox", "--disable-setuid-sandbox"],
     });
   });
@@ -162,6 +164,69 @@ describe("App", () => {
     const loadedIonCards = await page.$$(selectors.searchViewIonCard);
     expect(loadedIonCards.length).toBe(533); // list should contain all 533 songs.
   }, 20000);
+
+  it("displays arrow buttons and transitions correctly on lyrics mode", async () => {
+    await page.waitForSelector(selectors.shlSongbook);
+    await page.click(selectors.shlSongbook);
+
+    await page.waitForSelector(selectors.searchViewIonCardTitle);
+
+    const ionCards = await page.$$(selectors.searchViewIonCardTitle);
+    await ionCards[5].click();
+
+    await page.waitForSelector(selectors.lyricViewIonCardTitle);
+
+    expect(page.url()).toEqual(baseUrl + "/#/shl/6");
+    expect(await page.$eval(selectors.lyricViewIonCardTitle, (e) => e.innerHTML)).toEqual("Come, Thou Almighty King");
+
+    await page.waitForSelector(selectors.nextButton);
+    await page.click(selectors.nextButton);
+    
+    expect(page.url()).toEqual(baseUrl + "/#/shl/7");
+    expect(await page.$eval(selectors.lyricViewIonCardTitle, (e) => e.innerHTML)).toEqual("God, Our Father, We Adore Thee!");
+    
+    await page.waitForSelector(selectors.prevButton);
+    await page.click(selectors.prevButton);
+
+    expect(page.url()).toEqual(baseUrl + "/#/shl/6");
+    expect(await page.$eval(selectors.lyricViewIonCardTitle, (e) => e.innerHTML)).toEqual("Come, Thou Almighty King");
+  });
+
+  it("displays arrow buttons and transitions correctly on music mode", async () => {
+    await page.waitForSelector(selectors.shlSongbook);
+    await page.click(selectors.shlSongbook);
+
+    await page.waitForSelector(selectors.searchViewIonCardTitle);
+
+    const ionCards = await page.$$(selectors.searchViewIonCardTitle);
+    await ionCards[5].click();
+
+    await page.waitForSelector(selectors.songViewToggler);
+    await page.click(selectors.songViewToggler);
+
+    await page.waitForSelector(selectors.musicView);
+
+    expect(page.url()).toEqual(baseUrl + "/#/shl/6");
+    expect(await page.$eval(selectors.musicView, (e) => e.getAttribute("src"))).toEqual(
+      "https://raw.githubusercontent.com/Church-Life-Apps/Resources/master/resources/images/shl/SHL_006.png"
+    );
+
+    await page.waitForSelector(selectors.nextButton);
+    await page.click(selectors.nextButton);
+
+    expect(page.url()).toEqual(baseUrl + "/#/shl/7");
+    expect(await page.$eval(selectors.musicView, (e) => e.getAttribute("src"))).toEqual(
+      "https://raw.githubusercontent.com/Church-Life-Apps/Resources/master/resources/images/shl/SHL_007.png"
+    );
+
+    await page.waitForSelector(selectors.prevButton);
+    await page.click(selectors.prevButton);
+
+    expect(page.url()).toEqual(baseUrl + "/#/shl/6");
+    expect(await page.$eval(selectors.musicView, (e) => e.getAttribute("src"))).toEqual(
+      "https://raw.githubusercontent.com/Church-Life-Apps/Resources/master/resources/images/shl/SHL_006.png"
+    );
+  });
 
   afterAll(async () => {
     browser.close();


### PR DESCRIPTION
```
Issues:

- SongPage.tsx line 81 comment
- I want this to be a web only change (mobile should swipe for page change imo)
- breaks when you change page in lyric view (Eric said its something about lyric view implementation?)
```