### PR TITLE
fix(security): harden decrypt() against malformed UTF-8

### DIFF
--- a/src/utils/SecurityUtils.tsx
+++ b/src/utils/SecurityUtils.tsx
@@ -13,7 +13,16 @@ export function encrypt(normalText: string, privateKey: string): string {
 
 /**
  * Uses AES to decrypt some text with the given private key.
+ *
+ * Returns "" when decryption yields invalid UTF-8 (e.g. a wrong key produces
+ * random bytes) instead of throwing "Malformed UTF-8 data". This makes the
+ * function degrade gracefully for callers (e.g. FeedbackForm) and removes an
+ * intermittent ~6% failure in the wrong-key test case.
  */
 export function decrypt(encryptedtext: string, privateKey: string): string {
-  return CryptoJS.AES.decrypt(encryptedtext, privateKey).toString(CryptoJS.enc.Utf8);
+  try {
+    return CryptoJS.AES.decrypt(encryptedtext, privateKey).toString(CryptoJS.enc.Utf8);
+  } catch {
+    return "";
+  }
 }


### PR DESCRIPTION
## What

Hardens `decrypt()` in `src/utils/SecurityUtils.tsx` to catch malformed-UTF-8 and return `""` instead of throwing.

## Why

`CryptoJS.AES.decrypt(text, key).toString(CryptoJS.enc.Utf8)` validates the decrypted bytes as UTF-8. With a **wrong key**, those bytes are random — and ~**6%** of the time they're invalid UTF-8, so crypto-js throws `Malformed UTF-8 data` instead of returning garbage.

This made `SecurityUtils.test.tsx › Encrypt and Decrypt Test` (which asserts `decrypt(encrypted, "key2") !== text`) **intermittently fail in CI** — observed ~1/20 full-suite runs. Verified the underlying rate over 2000 iterations: ~6% per wrong-key call.

It's also a real robustness fix: `FeedbackForm.tsx` calls `decrypt(ENCRYPTED_TOKEN, PRIVATE_KEY)` for the Octokit token — a malformed-UTF-8 throw there would crash the feedback form rather than degrade gracefully.

## Change

```ts
export function decrypt(encryptedtext: string, privateKey: string): string {
  try {
    return CryptoJS.AES.decrypt(encryptedtext, privateKey).toString(CryptoJS.enc.Utf8);
  } catch {
    return "";
  }
}
```

Right-key decoding is unchanged. The existing test passes unchanged (`"" !== "hello world"` still holds).

## Verification

- 2000-iter repro confirmed the pre-fix ~6% throw rate; post-fix: 0 throws over 5000 iters, right-key decode 5000/5000 correct.
- Ran `SecurityUtils.test.tsx` 50× post-fix: **50/50 green**.
- ESLint + Prettier clean.

Scoped separately from the e2e suite PR (#257) per request; **not for immediate merge**.