### PR TITLE
feat: migrate analytics from dead UA to GA4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "ionicons": "^5.5.4",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
-        "react-ga": "^3.3.0",
+        "react-ga4": "^2.1.0",
         "react-router": "^5.2.1",
         "react-router-dom": "^5.3.0",
         "react-zoom-pan-pinch": "^1.6.1",
@@ -19125,14 +19125,10 @@
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==",
       "dev": true
     },
-    "node_modules/react-ga": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-3.3.1.tgz",
-      "integrity": "sha512-4Vc0W5EvXAXUN/wWyxvsAKDLLgtJ3oLmhYYssx+YzphJpejtOst6cbIHCIyF50Fdxuf5DDKqRYny24yJ2y7GFQ==",
-      "peerDependencies": {
-        "prop-types": "^15.6.0",
-        "react": "^15.6.2 || ^16.0 || ^17 || ^18"
-      }
+    "node_modules/react-ga4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-ga4/-/react-ga4-2.1.0.tgz",
+      "integrity": "sha512-ZKS7PGNFqqMd3PJ6+C2Jtz/o1iU9ggiy8Y8nUeksgVuvNISbmrQtJiZNvC/TjDsqD0QlU5Wkgs7i+w9+OjHhhQ=="
     },
     "node_modules/react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "ionicons": "^5.5.4",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
-    "react-ga": "^3.3.0",
+    "react-ga4": "^2.1.0",
     "react-router": "^5.2.1",
     "react-router-dom": "^5.3.0",
     "react-zoom-pan-pinch": "^1.6.1",

--- a/src/tracking/GoogleAnalytics.tsx
+++ b/src/tracking/GoogleAnalytics.tsx
@@ -1,13 +1,17 @@
-import ReactGA from "react-ga";
+import ReactGA from "react-ga4";
 
-const StreamID = "UA-183902236-1";
+// GA4 Measurement ID (migrated from the dead Universal Analytics property UA-183902236-1).
+const MeasurementID = "G-N1RESQYRT9";
 
 export const initGA = (): void => {
-  ReactGA.initialize(StreamID);
+  ReactGA.initialize(MeasurementID);
 };
 
 export const PageView = (): void => {
-  ReactGA.pageview(window.location.pathname + window.location.search);
+  ReactGA.send({
+    hitType: "pageview",
+    page: window.location.pathname + window.location.search,
+  });
   console.debug("Page viewed");
 };
 


### PR DESCRIPTION
## Summary

Migrates the v1 Songs app from **dead Universal Analytics** (no data since GA's UA shutdown) to **working GA4**.

### What was stale
- `package.json` depended on `react-ga@^3.3.0`, which loads legacy `analytics.js`.
- `src/tracking/GoogleAnalytics.tsx` initialized the dead UA property `UA-183902236-1` and used the retired `ReactGA.pageview()` / `ReactGA.event()` UA API. These hits go nowhere now that Universal Analytics is shut down.

### What GA4 now does
- Uses **`react-ga4`** (the maintained GA4 successor with a near-identical API).
- New **Measurement ID: `G-N1RESQYRT9`** (same analytics account, now a GA4 property).
- `initGA()` → `ReactGA.initialize("G-N1RESQYRT9")`
- `PageView()` → `ReactGA.send({ hitType: "pageview", page: ... })`
- `Event(category, action, label)` → `ReactGA.event({ category, action, label })`
- The build bundle now loads `gtag.js` from googletagmanager and tags the GA4 measurement ID.

### Public API preserved → no caller churn
The exported surface (`initGA`, `PageView`, `Event`, and the downstream `triggerSongView`) is unchanged, so all callers keep working with identical signatures and behavior:
- `src/App.tsx` (module-load `initGA(); PageView();`)
- `src/pages/SongPage.tsx` (`Event("INTERACTION", "Songmode is toggled", "SongMode_Toggle")`)
- `src/components/MusicView.tsx` / `src/components/LyricView.tsx` (`triggerSongView`)
- `src/tracking/EventFunctions.tsx`

No source changes were needed in any of those files.

### Dependency note (version choice)
Pinned to **`react-ga4@^2.1.0`**, the last **CommonJS** release. `react-ga4@3.x` is **ESM-only** (`"type": "module"`, `.mjs`/`.d.mts` only, no CJS entry) and fails to resolve under this app's older toolchain (`react-scripts 4` / Webpack 4 / TypeScript 3.9) — `npm run build` errors with `Cannot find module: 'react-ga4'`. `2.1.0` exposes the same `initialize` / `send` / `event` API and builds clean. (The "4" in `react-ga4` refers to GA4, not a major version — there is no `react-ga4@4.x`.) This kept us on the maintained library rather than falling back to a hand-rolled gtag snippet.

## Verification (CI-faithful, Node 16)

- `npm install -force` — clean swap (added react-ga4, removed react-ga).
- `npm run build` — ✅ success; bundle references `G-N1RESQYRT9` + `gtag`/googletagmanager. Old `UA-183902236` no longer in executable JS.
- `CI=true npm run test` — ✅ **118/118 tests passed, 6/6 suites** (full suite).
- `npx eslint` on touched files — ✅ clean.
- `npx prettier --check` on touched files — ✅ clean.

### Diff stat
```
 package-lock.json                | 14 +++++---------
 package.json                     |  2 +-
 src/tracking/GoogleAnalytics.tsx | 12 ++++++++----
 3 files changed, 14 insertions(+), 14 deletions(-)
```

🤖 Opened for review — **do not merge** until Eric signs off.
