### PR TITLE
fix: friendly "Song not found" for out-of-range songs (#147)

### DIFF
--- a/src/components/LyricView.tsx
+++ b/src/components/LyricView.tsx
@@ -35,6 +35,32 @@ const LyricView: React.FC<LyricViewProps> = (props: LyricViewProps) => {
     });
   }, [songId]);
 
+  // getSong() returns a sentinel song with songNumber === -1 when the requested
+  // song number is missing or out of range (e.g. /#/<book>/0 or /#/<book>/<N+1>).
+  // Render a friendly "Song not found" message instead of a blank card with a
+  // stray "By" author row (#147).
+  const isNotFound = !song || song.songNumber === -1;
+
+  if (isNotFound) {
+    return (
+      <IonGrid>
+        <IonRow class="ion-justify-content-center">
+          <IonCol size="12" size-lg="8" size-xl="6" className="song-page-center">
+            <IonCard id="lyricViewCard" className="ion-padding">
+              <IonCardHeader className="ion-text-center">
+                <IonCardTitle key="title">Song not found</IonCardTitle>
+              </IonCardHeader>
+              <IonCardContent key="notFound" id="lyricViewNotFound">
+                <p>We couldn&apos;t find that song. It may not exist in this songbook.</p>
+                <p>Please double-check the song number and try again.</p>
+              </IonCardContent>
+            </IonCard>
+          </IonCol>
+        </IonRow>
+      </IonGrid>
+    );
+  }
+
   return (
     <IonGrid>
       <IonRow class="ion-justify-content-center">

--- a/src/components/LyricView.tsx
+++ b/src/components/LyricView.tsx
@@ -14,7 +14,7 @@ import { PLACEHOLDER_SONG, Song, SongViewMode } from "../utils/SongUtils";
 import "./Components.css";
 //Import Event tracking
 import { triggerSongView } from "../tracking/EventFunctions";
-import { getSong } from "../service/SongsService";
+import { getSong, getNumSongsForBookId } from "../service/SongsService";
 import { useParams } from "react-router";
 
 interface LyricViewProps {
@@ -26,6 +26,7 @@ interface LyricViewProps {
  */
 const LyricView: React.FC<LyricViewProps> = (props: LyricViewProps) => {
   const [song, setSong] = useState<Song>(PLACEHOLDER_SONG);
+  const [numSongs, setNumSongs] = useState<number>(0);
   const { bookId, songId } = useParams<{ bookId: string; songId: string }>();
 
   useEffect(() => {
@@ -35,6 +36,11 @@ const LyricView: React.FC<LyricViewProps> = (props: LyricViewProps) => {
     });
   }, [songId]);
 
+  // Song count for this book, used to show the valid range in the not-found message.
+  useEffect(() => {
+    getNumSongsForBookId(bookId).then(setNumSongs);
+  }, [bookId]);
+
   // getSong() returns a sentinel song with songNumber === -1 when the requested
   // song number is missing or out of range (e.g. /#/<book>/0 or /#/<book>/<N+1>).
   // Render a friendly "Song not found" message instead of a blank card with a
@@ -42,6 +48,11 @@ const LyricView: React.FC<LyricViewProps> = (props: LyricViewProps) => {
   const isNotFound = !song || song.songNumber === -1;
 
   if (isNotFound) {
+    // The raw `songId` param is what the user actually requested (a number like
+    // "9999", or a non-numeric value like "abc"). Show it back to them along with
+    // the valid range so they know what to try instead.
+    const requested = songId;
+    const rangeText = numSongs > 0 ? `This songbook has songs 1\u2013${numSongs}.` : "";
     return (
       <IonGrid>
         <IonRow class="ion-justify-content-center">
@@ -51,8 +62,10 @@ const LyricView: React.FC<LyricViewProps> = (props: LyricViewProps) => {
                 <IonCardTitle key="title">Song not found</IonCardTitle>
               </IonCardHeader>
               <IonCardContent key="notFound" id="lyricViewNotFound">
-                <p>We couldn&apos;t find that song. It may not exist in this songbook.</p>
-                <p>Please double-check the song number and try again.</p>
+                <p>
+                  We couldn&apos;t find song <strong>{requested}</strong> in this songbook.
+                </p>
+                {rangeText !== "" ? <p>{rangeText} Please check the number and try again.</p> : <p>Please check the number and try again.</p>}
               </IonCardContent>
             </IonCard>
           </IonCol>

--- a/src/service/SongsService.tsx
+++ b/src/service/SongsService.tsx
@@ -55,7 +55,10 @@ export async function getNumSongsForBookId(bookId: string): Promise<number> {
  */
 export async function getSong(number: number, bookId: string): Promise<Song> {
   const songs = await getOrfetchSongs(bookId);
-  if (isNaN(number) || number < 0 || number > songs.length) {
+  // Treat 0, negatives, NaN, and anything past the last song as out-of-range.
+  // Returning songNumber:-1 signals "not found" so the UI can render a friendly
+  // message instead of a blank card with a stray author row (#147).
+  if (isNaN(number) || number < 1 || number > songs.length || !songs[number - 1]) {
     return { title: "", author: "", songNumber: -1, lyrics: new Map(), presentation: "" };
   } else {
     if (!(songs[number - 1].lyrics instanceof Map)) {

--- a/src/test/e2e/Layer1.data.test.tsx
+++ b/src/test/e2e/Layer1.data.test.tsx
@@ -144,7 +144,7 @@ describe.each<BookId>(["shl", "sfog"])("Layer 1 — %s sampled data", bookId => 
     }
   }, 90000);
 
-  it("out-of-range song numbers (0 and N+1) document current behavior (#147)", async () => {
+  it("out-of-range song numbers (0 and N+1) render a friendly not-found message (#147)", async () => {
     // Derive the high edge from live data: one past the largest real song number.
     const maxSongNumber = songs.reduce((m, s) => Math.max(m, s.songNumber), 0);
     const edges = [0, maxSongNumber + 1];
@@ -153,18 +153,17 @@ describe.each<BookId>(["shl", "sfog"])("Layer 1 — %s sampled data", bookId => 
       try {
         await page.goto(songUrl(bookId, edge), { waitUntil: "domcontentloaded" });
         await page.waitForSelector(selectors.lyricViewIonCardTitle, { timeout: 15000 });
-        // Allow the async getSong() to resolve.
+        // Allow the async getSong() to resolve to the not-found sentinel.
         await delay(2500);
         const title = await page.$eval(selectors.lyricViewIonCardTitle, e => e.innerHTML);
 
-        // KNOWN BUG #147: out-of-range numbers render a blank song card instead of
-        // a friendly "Song not found" message. getSong() returns songNumber:-1 for
-        // numbers > N (rendered as "-1) "), and leaves the "0) " placeholder for 0.
-        // We assert the CURRENT (buggy) behavior so the suite stays green; when #147
-        // is fixed, this expectation should be updated to the friendly state.
-        expect(title === "0) " || title === "-1) " || title.startsWith("-1)") || title.startsWith("0)")).toBe(true);
+        // FIXED #147: out-of-range numbers now render a friendly "Song not found"
+        // card instead of a blank "0) " / "-1) " placeholder.
+        expect(title.trim()).toBe("Song not found");
+        // No stray "N) " numbering prefix should appear.
+        expect(title).not.toMatch(/-?\d+\)/);
 
-        // Author row should be absent for the blank placeholder song.
+        // Author row should be absent for the not-found state.
         const authorEl = await page.$(selectors.lyricViewAuthor);
         expect(authorEl).toBeNull();
       } finally {

--- a/src/test/e2e/Layer1.data.test.tsx
+++ b/src/test/e2e/Layer1.data.test.tsx
@@ -163,6 +163,11 @@ describe.each<BookId>(["shl", "sfog"])("Layer 1 — %s sampled data", bookId => 
         // No stray "N) " numbering prefix should appear.
         expect(title).not.toMatch(/-?\d+\)/);
 
+        // The message echoes the requested song number and states the valid range.
+        const notFoundText = await page.$eval(selectors.lyricViewNotFound, e => e.textContent || "");
+        expect(notFoundText).toContain(String(edge));
+        expect(notFoundText).toContain(`1\u2013${maxSongNumber}`);
+
         // Author row should be absent for the not-found state.
         const authorEl = await page.$(selectors.lyricViewAuthor);
         expect(authorEl).toBeNull();

--- a/src/test/e2e/Layer2.features.test.tsx
+++ b/src/test/e2e/Layer2.features.test.tsx
@@ -789,20 +789,19 @@ describe("Feedback form (F25) — mocked GitHub API", () => {
  * Edge cases (F: error states) — bad songId in URL.
  * ------------------------------------------------------------------------- */
 describe("Edge cases", () => {
-  it("non-numeric songId in URL does not crash the app (#TODO error handling)", async () => {
+  it("non-numeric songId in URL renders a friendly not-found message (#147)", async () => {
     const page = await newPage(browser, "desktop");
     try {
-      // KNOWN GAP: SongPage has "// TODO: Add error handling in case of non number
-      // song Id". currSongId becomes NaN; getSong returns the blank placeholder.
-      // We assert the app stays alive and renders the lyric card shell rather
-      // than asserting a friendly message (which isn't implemented yet).
+      // currSongId becomes NaN for a non-numeric songId; getSong returns the
+      // not-found sentinel (songNumber:-1), which LyricView renders as a friendly
+      // "Song not found" card instead of a blank placeholder (#147).
       await page.goto(`${baseUrl}/#/shl/abc`, { waitUntil: "domcontentloaded" });
       await page.waitForSelector(selectors.lyricViewCard, { timeout: 15000 });
-      await delay(1500);
+      await delay(2500);
       const title = await page.$eval(selectors.lyricViewIonCardTitle, e => e.innerHTML);
-      // Placeholder blank song renders ("0) " before fetch, "-1) " for NaN guard).
-      expect(typeof title).toBe("string");
-      expect(title.includes(")")).toBe(true);
+      // App stays alive and shows the friendly not-found state, no "N) " prefix.
+      expect(title.trim()).toBe("Song not found");
+      expect(title).not.toMatch(/-?\d+\)/);
     } finally {
       await page.close();
     }

--- a/src/test/e2e/Layer2.features.test.tsx
+++ b/src/test/e2e/Layer2.features.test.tsx
@@ -802,6 +802,11 @@ describe("Edge cases", () => {
       // App stays alive and shows the friendly not-found state, no "N) " prefix.
       expect(title.trim()).toBe("Song not found");
       expect(title).not.toMatch(/-?\d+\)/);
+
+      // The message echoes the requested (non-numeric) songId and the valid range.
+      const notFoundText = await page.$eval(selectors.lyricViewNotFound, e => e.textContent || "");
+      expect(notFoundText).toContain("abc");
+      expect(notFoundText).toMatch(/1\u2013\d+/);
     } finally {
       await page.close();
     }

--- a/src/test/helpers/e2e.ts
+++ b/src/test/helpers/e2e.ts
@@ -48,6 +48,7 @@ export const selectors = {
   lyricViewCard: "#lyricViewCard",
   lyricViewIonCardTitle: "#lyricViewCard > ion-card-header > ion-card-title",
   lyricViewAuthor: "#lyricViewCard > ion-card-header > ion-card-subtitle",
+  lyricViewNotFound: "#lyricViewNotFound",
   musicView: "#musicView",
   songViewToggler: "#songViewToggler",
   songToggler: "#songToggler", // second-tune toggle wrapper (SHL only)


### PR DESCRIPTION
## Bug (#147)

Navigating to an out-of-range song URL such as `/#/<book>/0`, `/#/<book>/<N+1>`, or a non-numeric `/#/<book>/abc` rendered a **blank song card** with a stray `0) ` / `-1) ` title and (previously) a dangling "By" author row — looking like the data had failed to load.

Root cause:
- `getSong()` returned a sentinel song with `songNumber: -1` for numbers `> N`, which `LyricView` rendered literally as `"-1) "`.
- For `0`, the lower bound was `number < 0`, so `0` slipped through to `songs[-1]` (undefined) — leaving the `PLACEHOLDER_SONG` (`0) `) on screen.

## Fix

- **`SongsService.getSong`** — tightened the out-of-range guard to `number < 1 || number > songs.length || !songs[number - 1]`, so `0`, negatives, `NaN`, and `N+1` all return the `songNumber: -1` not-found sentinel.
- **`LyricView`** — detects the sentinel (`song.songNumber === -1`) and renders a friendly **"Song not found"** card instead of a blank one. The message **echoes the requested song number and states the valid range**, e.g. *"We couldn't find song **9999** in this songbook. This songbook has songs **1–533**. Please check the number and try again."* No `N) ` numbering prefix and no author row in this state. The valid range is read live from the songbook (`getNumSongsForBookId`), so it stays correct per book.

## Before / After

Out-of-range number `/#/shl/9999`:

| Before (master) | After (this PR) |
| --- | --- |
| ![before](https://raw.githubusercontent.com/Church-Life-Apps/Songs/718bd97bf84b2c4988f087ae777b24e977e1e037/docs/pr-assets/264-before.png) | ![after](https://raw.githubusercontent.com/Church-Life-Apps/Songs/718bd97bf84b2c4988f087ae777b24e977e1e037/docs/pr-assets/264-after.png) |

Non-numeric `/#/shl/abc` (After):

![after-abc](https://raw.githubusercontent.com/Church-Life-Apps/Songs/718bd97bf84b2c4988f087ae777b24e977e1e037/docs/pr-assets/264-after-abc.png)

**Before:** blank card with a stray `-1)` title fragment, no message.
**After:** a "Song not found" card that names what was requested (`9999` or `abc`) and the valid range (`1–533` for SHL) — no stray number, no author row.

## Test updates

This change intentionally alters previously-documented buggy behavior, so the `#147` e2e assertions were updated and strengthened:

- **`Layer1.data.test.tsx`** — the out-of-range test (`0` and `N+1`) now asserts the **friendly not-found state**: title is exactly `Song not found`, no `N) ` prefix, no author row, **and** the card body contains the requested number and the valid `1–N` range.
- **`Layer2.features.test.tsx`** — the non-numeric-songId test (`/#/shl/abc`) now asserts the friendly message **and** that the body echoes `abc` plus the `1–N` range.
- Added a `lyricViewNotFound` selector (`#lyricViewNotFound`) for these assertions.

Both updated tests pass locally; `npm run build` is clean.

Fixes #147
