### PR TITLE
fix: validate sheet-music download is a real image (#211)

### DIFF
--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -44,17 +44,66 @@ const NavigationBar: React.FC<NavigationBarProps> = props => {
 
   // The reason we need this is beacuse you cannot download things cross origin
   // but blob data is considered same origin, so here we fetch the image data and
-  // create a blob url and we then use that blob url when we render the download button
+  // create a blob url and we then use that blob url when we render the download button.
+  //
+  // #211: occasionally the fetch resolves to an HTML error/cache page instead of
+  // the PNG, so the download saved a .html disguised as an image. We now
+  // cache-bust the request and validate the response (ok + image content-type)
+  // before creating a blob url; otherwise we surface an error and leave the
+  // download button without a usable href.
   useEffect(() => {
-    fetch(props.musicPageUrl as string)
-      .then(response => response.blob())
-      .then(blob => {
-        const blobUrl = URL.createObjectURL(blob);
-        if (songPageBlobUrl !== blobUrl) {
-          setSongPageBlobUrl(blobUrl);
+    if (!props.musicPageUrl) {
+      return;
+    }
+
+    let revoked = false;
+    let createdBlobUrl: string | null = null;
+
+    // Cache-bust so we don't get a stale/HTML cache entry from a CDN/service worker.
+    const separator = props.musicPageUrl.includes("?") ? "&" : "?";
+    const bustedUrl = `${props.musicPageUrl}${separator}_=${Date.now()}`;
+
+    fetch(bustedUrl, { cache: "no-store" })
+      .then(async response => {
+        if (!response.ok) {
+          throw new Error(`Sheet music request failed with status ${response.status}`);
         }
+        const contentType = response.headers.get("content-type") || "";
+        const blob = await response.blob();
+        const blobType = blob.type || "";
+        // Must be a real image (PNG). Reject HTML error/cache pages.
+        const looksLikeImage =
+          contentType.includes("image/png") ||
+          contentType.includes("image/") ||
+          blobType.includes("image/");
+        const looksLikeHtml = contentType.includes("text/html") || blobType.includes("text/html");
+        if (!looksLikeImage || looksLikeHtml) {
+          throw new Error(`Sheet music response was not a valid image (content-type: ${contentType || blobType})`);
+        }
+        return blob;
       })
-      .catch(e => console.error(e));
+      .then(blob => {
+        if (revoked) {
+          return;
+        }
+        const blobUrl = URL.createObjectURL(blob);
+        createdBlobUrl = blobUrl;
+        setSongPageBlobUrl(blobUrl);
+      })
+      .catch(e => {
+        console.error(e);
+        // Fail gracefully: clear any stale blob url so we don't offer a bad download.
+        if (!revoked) {
+          setSongPageBlobUrl("");
+        }
+      });
+
+    return () => {
+      revoked = true;
+      if (createdBlobUrl) {
+        URL.revokeObjectURL(createdBlobUrl);
+      }
+    };
   }, [props.musicPageUrl]);
 
   return (


### PR DESCRIPTION
## Bug (#211)

The sheet-music download button fetches the music image URL (`props.musicPageUrl`), turns the response into a blob, and exposes it as a same-origin blob URL for download. Occasionally the fetch resolved to an **HTML error / CDN cache page** rather than the PNG, so the user downloaded an `.html` file masquerading as sheet music.

The previous handler called `response.blob()` unconditionally — it never checked `response.ok` or the content-type, so any 200-with-HTML (or cached error page) was happily saved.

## Fix

In `src/components/NavigationBar.tsx`, per the issue's own guidance:

- **(a) Cache-bust** the request: append `?_=${Date.now()}` (respecting any existing query string) and use `cache: "no-store"`, so a stale/HTML cache entry isn't reused.
- **(b) Validate** before creating the blob URL: require `response.ok` **and** that the content-type (or resolved blob type) is an image (`image/png` / `image/*`) and explicitly **not** `text/html`.
- **(c) Fail gracefully**: on a bad/invalid response the error is logged and the blob URL is cleared (`setSongPageBlobUrl("")`) so we don't offer a broken download instead of silently saving garbage.

Also added proper cleanup — the created object URL is revoked on unmount / URL change to avoid leaks, and a `revoked` guard prevents setting state after teardown.

Verified locally with `CI=true npm run build` (clean). CI runs the full e2e suite (which includes the existing `guards #211` music-image content-type assertions in `Layer1.data.test.tsx`).

Fixes #211