### PR TITLE
fix: harden section-label mapping for multi-char verse keys

### DIFF
--- a/src/components/LyricView.tsx
+++ b/src/components/LyricView.tsx
@@ -11,6 +11,7 @@ import {
 } from "@ionic/react";
 import React, { Fragment, useEffect, useState } from "react";
 import { PLACEHOLDER_SONG, Song, SongViewMode } from "../utils/SongUtils";
+import { getSectionLabel } from "../utils/LyricUtils";
 import "./Components.css";
 //Import Event tracking
 import { triggerSongView } from "../tracking/EventFunctions";
@@ -112,21 +113,7 @@ const LyricView: React.FC<LyricViewProps> = (props: LyricViewProps) => {
   }
 
   function getVerseText(verse: string) {
-    const lower = verse.toLowerCase();
-    const prefix = lower.charAt(0);
-    const rest = lower.slice(1);
-    const labels: { [key: string]: string } = {
-      i: "Interlude",
-      v: "Verse",
-      c: "Chorus",
-      b: "Bridge",
-      p: "Pre-Chorus",
-      t: "Tag",
-      e: "Ending",
-    };
-    const label = labels[prefix];
-    if (!label) return verse;
-    return rest ? `${label} ${rest}` : label;
+    return getSectionLabel(verse);
   }
 
   function buildLyricBlock(name: string, lines: string[], key: number) {

--- a/src/test/helpers/e2e.ts
+++ b/src/test/helpers/e2e.ts
@@ -177,25 +177,34 @@ export function makeThreeDigits(num: number): string {
 }
 
 /**
- * Replicates the app's getVerseText label mapping (LyricView.tsx) so tests can
- * compute the expected verse-label sequence from a song's presentation string.
+ * Replicates the app's section-label mapping (src/utils/LyricUtils.ts /
+ * getSectionLabel, surfaced via LyricView.tsx) so tests can compute the
+ * expected verse-label sequence from a song's presentation string.
+ *
+ * Uses an ordered longest-prefix-first map so multi-character keys like "pc"
+ * map to "Pre-Chorus" rather than "Pre-Chorus Chorus". Returns the label
+ * trimmed, matching how the rendered DOM text is read (.trim()) in the e2e
+ * assertions.
  */
 export function verseLabel(key: string): string {
   const lower = key.toLowerCase();
-  const prefix = lower.charAt(0);
-  const rest = lower.slice(1);
-  const labels: { [k: string]: string } = {
-    i: "Interlude",
-    v: "Verse",
-    c: "Chorus",
-    b: "Bridge",
-    p: "Pre-Chorus",
-    t: "Tag",
-    e: "Ending",
-  };
-  const label = labels[prefix];
-  if (!label) return key;
-  return rest ? `${label} ${rest}` : label;
+  const prefixes: Array<[string, string]> = [
+    ["pc", "Pre-Chorus"],
+    ["v", "Verse"],
+    ["c", "Chorus"],
+    ["b", "Bridge"],
+    ["p", "Pre-Chorus"],
+    ["i", "Interlude"],
+    ["t", "Tag"],
+    ["e", "Ending"],
+  ];
+  for (const [prefix, label] of prefixes) {
+    if (lower.startsWith(prefix)) {
+      const suffix = lower.slice(prefix.length);
+      return suffix ? `${label} ${suffix}` : label;
+    }
+  }
+  return key;
 }
 
 /**

--- a/src/test/utils/LyricUtils.test.tsx
+++ b/src/test/utils/LyricUtils.test.tsx
@@ -1,0 +1,42 @@
+import { getSectionLabel } from "../../utils/LyricUtils";
+
+describe("Lyric Utils Tests", () => {
+  it("maps the multi-char 'pc' prefix to Pre-Chorus (regression #251/#252)", () => {
+    // Previously the chained single-char mapping turned "pc" into
+    // "Pre-Chorus Chorus ". Longest-prefix-first must yield Pre-Chorus only.
+    expect(getSectionLabel("pc")).toBe("Pre-Chorus ");
+    expect(getSectionLabel("pc1")).toBe("Pre-Chorus 1");
+    expect(getSectionLabel("pc2")).toBe("Pre-Chorus 2");
+  });
+
+  it("does not mangle other multi-char keys", () => {
+    // "bc" starts with "b" (Bridge); the trailing "c" is kept as the suffix
+    // rather than being re-expanded into "Chorus".
+    expect(getSectionLabel("bc")).toBe("Bridge c");
+  });
+
+  it("maps single-letter prefixes with a numeric suffix", () => {
+    expect(getSectionLabel("v1")).toBe("Verse 1");
+    expect(getSectionLabel("c2")).toBe("Chorus 2");
+    expect(getSectionLabel("p1")).toBe("Pre-Chorus 1");
+  });
+
+  it("maps bare single-letter keys to the label with a trailing space", () => {
+    expect(getSectionLabel("v")).toBe("Verse ");
+    expect(getSectionLabel("c")).toBe("Chorus ");
+    expect(getSectionLabel("b")).toBe("Bridge ");
+    expect(getSectionLabel("p")).toBe("Pre-Chorus ");
+  });
+
+  it("is case-insensitive", () => {
+    expect(getSectionLabel("PC")).toBe("Pre-Chorus ");
+    expect(getSectionLabel("PC3")).toBe("Pre-Chorus 3");
+    expect(getSectionLabel("V1")).toBe("Verse 1");
+    expect(getSectionLabel("B")).toBe("Bridge ");
+  });
+
+  it("returns the original key unchanged for an unknown prefix", () => {
+    expect(getSectionLabel("x9")).toBe("x9");
+    expect(getSectionLabel("zzz")).toBe("zzz");
+  });
+});

--- a/src/utils/LyricUtils.ts
+++ b/src/utils/LyricUtils.ts
@@ -1,0 +1,52 @@
+/**
+ * Util functions for rendering lyric section labels.
+ */
+
+/**
+ * Ordered map of verse-key prefixes to friendly section labels.
+ *
+ * Order matters: longer prefixes MUST come before any shorter prefix they
+ * share a leading character with, so that a multi-character key like "pc"
+ * matches "Pre-Chorus " (prefix "pc") rather than being treated as prefix "p"
+ * followed by a stray "c" (which produced the "Pre-Chorus Chorus " bug).
+ *
+ * Each value already includes a trailing space so that a numeric suffix
+ * (e.g. "v1" -> "Verse 1") reads naturally; bare keys keep the trailing space
+ * (e.g. "v" -> "Verse "). Callers that render into the DOM trim as needed.
+ */
+const SECTION_PREFIXES: Array<[string, string]> = [
+  ["pc", "Pre-Chorus "],
+  ["v", "Verse "],
+  ["c", "Chorus "],
+  ["b", "Bridge "],
+  ["p", "Pre-Chorus "],
+  ["i", "Interlude "],
+  ["t", "Tag "],
+  ["e", "Ending "],
+];
+
+/**
+ * Converts a verse key (e.g. "v1", "pc2", "c", "bc") into its friendly section
+ * label by matching the FIRST (longest-first) prefix in SECTION_PREFIXES and
+ * appending whatever follows the prefix as a suffix.
+ *
+ * Examples:
+ *   getSectionLabel("pc")  -> "Pre-Chorus "
+ *   getSectionLabel("pc1") -> "Pre-Chorus 1"
+ *   getSectionLabel("v1")  -> "Verse 1"
+ *   getSectionLabel("c2")  -> "Chorus 2"
+ *   getSectionLabel("b")   -> "Bridge "
+ *
+ * The match is case-insensitive. Keys with no recognized prefix are returned
+ * unchanged (e.g. an unknown "x9" -> "x9").
+ */
+export function getSectionLabel(verse: string): string {
+  const lower = verse.toLowerCase();
+  for (const [prefix, label] of SECTION_PREFIXES) {
+    if (lower.startsWith(prefix)) {
+      const suffix = lower.slice(prefix.length);
+      return `${label}${suffix}`;
+    }
+  }
+  return verse;
+}


### PR DESCRIPTION
## Bug (#251, #252)
`getVerseText` in `LyricView.tsx` mapped verse keys to friendly section labels using a single leading character (`v`→Verse, `c`→Chorus, `b`→Bridge, `p`→Pre-Chorus, …). Multi-character keys were mangled:

- `pc` (Pre-Chorus) → the `p` prefix matched, then the trailing `c` was rendered literally, producing **`Pre-Chorus c`** (and under the older chained-`.replace()` form, `Pre-Chorus Chorus`).

Any key whose first letter collides with a longer real prefix was at risk.

## Fix
Extracted a tested helper `getSectionLabel` into **`src/utils/LyricUtils.ts`** that uses an **ordered, longest-prefix-first** map:

```ts
const SECTION_PREFIXES: Array<[string, string]> = [
  ["pc", "Pre-Chorus "], ["v", "Verse "], ["c", "Chorus "],
  ["b", "Bridge "], ["p", "Pre-Chorus "], ["i", "Interlude "],
  ["t", "Tag "], ["e", "Ending "],
];
```

The key is lowercased; the **first** matching prefix wins (so `pc` matches before `p`), and everything after the prefix (e.g. trailing digits) is appended as the suffix. `LyricView` now delegates to this helper. Unknown prefixes fall through and return the original key unchanged.

## Files changed
- `src/utils/LyricUtils.ts` (new) — `getSectionLabel` helper.
- `src/components/LyricView.tsx` — `getVerseText` now delegates to `getSectionLabel`.
- `src/test/utils/LyricUtils.test.tsx` (new) — covers `pc`/`pc1`/`pc2`, `bc`, `v1`, `c2`, `b`, `p1`, case-insensitivity, and unknown-prefix fall-through.
- `src/test/helpers/e2e.ts` — kept the e2e `verseLabel` replica in sync with the new longest-prefix-first logic so Layer1/Layer2 expectations stay correct.

## Verification
- `CI=true npx react-scripts test src/test/utils/LyricUtils.test.tsx` → **6 passing**.
- `npm run build` → **clean**.

Fixes #251
Fixes #252
