### PR TITLE
fix: search input one keystroke behind on iOS (onIonChange -> onIonInput)

### DIFF
--- a/src/pages/BookPage.tsx
+++ b/src/pages/BookPage.tsx
@@ -61,10 +61,7 @@ const BookPage: React.FC = () => {
           type="search"
           value={searchString}
           placeholder="Search for a song"
-          // Use onIonInput (fires on every keystroke) instead of onIonChange,
-          // which on iOS lags one keystroke behind. In Ionic 5 the ionInput
-          // event detail is a KeyboardEvent, so read the current value from the
-          // input element itself to keep the field fully controlled.
+          // onIonInput (not onIonChange) fires every keystroke; on iOS onIonChange lags one behind (#104).
           onIonInput={e => setSearchString((e.target as HTMLIonInputElement).value as string)}
         ></IonInput>
         {searchString !== "" && (

--- a/src/pages/BookPage.tsx
+++ b/src/pages/BookPage.tsx
@@ -61,7 +61,11 @@ const BookPage: React.FC = () => {
           type="search"
           value={searchString}
           placeholder="Search for a song"
-          onIonChange={word => setSearchString(word.detail.value as string)}
+          // Use onIonInput (fires on every keystroke) instead of onIonChange,
+          // which on iOS lags one keystroke behind. In Ionic 5 the ionInput
+          // event detail is a KeyboardEvent, so read the current value from the
+          // input element itself to keep the field fully controlled.
+          onIonInput={e => setSearchString((e.target as HTMLIonInputElement).value as string)}
         ></IonInput>
         {searchString !== "" && (
           <IonButton shape="round" fill="clear" color="medium" onClick={() => clearSearchText()}>


### PR DESCRIPTION
## Bug (#104)
On iOS the search field was one keystroke behind: typing `362` searched for `36`. The input used Ionic's `onIonChange`, which on iOS fires late (effectively after the next keystroke / on blur-ish timing), so the value React received always trailed what the user had typed.

## Fix
Switched the search `IonInput` from `onIonChange` to **`onIonInput`**, which fires synchronously on every keystroke. In Ionic 5 the `ionInput` event detail is a `KeyboardEvent` (not the value), so the handler reads the current value off the input element (`e.target.value`) to keep the field fully controlled via the existing `searchString` state.

No behavior otherwise changes:
- The field stays controlled (`value={searchString}`), so the clear button and the restored-from-localStorage value still work.
- The 200ms results debounce in the `useEffect` is untouched, so it batches result fetches without dropping any keystrokes — the input itself now updates immediately.

## Files changed
- `src/pages/BookPage.tsx` — `onIonChange` → `onIonInput` on the search input.

## Verification

The underlying bug is an **iOS-WebKit-only timing quirk** and does not reproduce in headless Chrome, so this isn't a captured before/after of the iOS lag. Instead this verifies the fix **works and doesn't regress search** in a real browser — i.e. `onIonInput` keeps the field fully controlled and search stays in lock-step with what's typed.

Ran against the `fix/search-input-lag` branch dev build, driving the real search box keystroke-by-keystroke (Chromium, mobile viewport):

| Action | Expected field value | Actual | ✓ |
| --- | --- | --- | --- |
| type `3` | `3` | `3` | ✅ |
| type `6` | `36` | `36` | ✅ |
| type `2` | `362` | `362` | ✅ |
| backspace | `36` | `36` | ✅ |
| backspace | `3` | `3` | ✅ |
| retype to `362` | `362` | `362` | ✅ |

After the final keystroke the field value is the **full** typed string (not one behind), on both forward typing and deletes, and the result list filters to exactly the matching song:

![search 362](https://raw.githubusercontent.com/Church-Life-Apps/Songs/pr-review-assets/docs/pr-assets/267-after.png)

Typing `362` filters to a single result — *"362. There Is Always Something Over"* — confirming the filtered state reflects the complete input, with no one-keystroke lag.

- `npm run build` on this branch → **clean**.
- CI e2e suite drives the search box via real keystrokes in Layer2, exercising `onIonInput` directly.

Fixes #104
