### PR TITLE
fix: auto-load song list past initial page on tall viewports (#242)

### DIFF
--- a/src/components/SearchView.tsx
+++ b/src/components/SearchView.tsx
@@ -5,10 +5,11 @@ import {
   IonCardSubtitle,
   IonLabel,
   IonItem,
+  IonButton,
   IonInfiniteScroll,
   IonInfiniteScrollContent,
 } from "@ionic/react";
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useParams, useHistory } from "react-router-dom";
 import { Song } from "../utils/SongUtils";
 import "./Components.css";
@@ -17,6 +18,9 @@ interface SearchViewProps {
   songs: Song[];
 }
 
+const INITIAL_PAGE_SIZE = 30;
+const PAGE_SIZE = 10;
+
 /**
  * Search View.
  */
@@ -24,21 +28,86 @@ const SearchView: React.FC<SearchViewProps> = (props: SearchViewProps) => {
   const { bookId } = useParams<{ bookId: string }>();
   const [songCards, setSongCards] = useState<JSX.Element[]>([]);
   const [songCardsIterator] = useState(props.songs.entries());
+  // Whether the iterator has been exhausted (all songs rendered).
+  const [allLoaded, setAllLoaded] = useState<boolean>(false);
 
+  const wrapperRef = useRef<HTMLDivElement>(null);
   const history = useHistory();
 
   if (songCards.length === 0) {
-    LoadSongs(songCardsIterator, 30);
+    LoadSongs(songCardsIterator, INITIAL_PAGE_SIZE);
   }
+
+  // #242: On viewports tall enough to fit the entire initial page without any
+  // vertical overflow, IonInfiniteScroll's onIonInfinite never fires (there is
+  // nothing to scroll), leaving the rest of the songs unreachable. After every
+  // render, if the scroll container is not overflowing and songs remain, keep
+  // loading the next page until it overflows or all songs are loaded.
+  useEffect(() => {
+    if (allLoaded) {
+      return;
+    }
+    let cancelled = false;
+
+    const isOverflowing = (): boolean => {
+      // Prefer the nearest Ionic scroll container; fall back to the document.
+      const wrapper = wrapperRef.current;
+      const ionContent = wrapper ? wrapper.closest("ion-content") : null;
+      const inner = ionContent ? (ionContent.querySelector(".inner-scroll") as HTMLElement | null) : null;
+      if (inner) {
+        return inner.scrollHeight > inner.clientHeight + 1;
+      }
+      const doc = document.documentElement;
+      return doc.scrollHeight > doc.clientHeight + 1;
+    };
+
+    // Defer to after layout so heights are measured post-paint.
+    const handle = window.setTimeout(() => {
+      if (cancelled) {
+        return;
+      }
+      if (!isOverflowing()) {
+        const more = LoadSongs(songCardsIterator, PAGE_SIZE);
+        setSongCards(Array.from(songCards));
+        if (!more) {
+          setAllLoaded(true);
+        }
+      }
+    }, 50);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(handle);
+    };
+  }, [songCards, allLoaded]);
+
   return songCards.length > 0 ? (
-    <div>
+    <div ref={wrapperRef}>
       <IonList id="searchViewSongList">{songCards}</IonList>
-      <IonInfiniteScroll onIonInfinite={LoadMoreSongs}>
+      <IonInfiniteScroll disabled={allLoaded} onIonInfinite={LoadMoreSongs}>
         <IonInfiniteScrollContent
           loadingSpinner="bubbles"
           loadingText="Loading more songs..."
         ></IonInfiniteScrollContent>
       </IonInfiniteScroll>
+      {/* Fallback for tall viewports where the infinite-scroll trigger has
+          nothing to observe (#242): an explicit button to load the next page. */}
+      {!allLoaded && (
+        <IonButton
+          id="loadMoreSongsButton"
+          expand="block"
+          fill="clear"
+          onClick={() => {
+            const more = LoadSongs(songCardsIterator, PAGE_SIZE);
+            setSongCards(Array.from(songCards));
+            if (!more) {
+              setAllLoaded(true);
+            }
+          }}
+        >
+          Load more songs
+        </IonButton>
+      )}
     </div>
   ) : (
     <IonItem>
@@ -48,8 +117,9 @@ const SearchView: React.FC<SearchViewProps> = (props: SearchViewProps) => {
 
   function LoadMoreSongs(event: CustomEvent<void>) {
     const target = event.target as HTMLIonInfiniteScrollElement;
-    if (!LoadSongs(songCardsIterator, 10)) {
+    if (!LoadSongs(songCardsIterator, PAGE_SIZE)) {
       target.disabled = true;
+      setAllLoaded(true);
     }
     setSongCards(Array.from(songCards));
     target.complete();

--- a/src/test/e2e/Layer2.features.test.tsx
+++ b/src/test/e2e/Layer2.features.test.tsx
@@ -319,31 +319,31 @@ describe.each(BOOK_IDS)("Infinite scroll [%s]", bookId => {
     }
   }, 60000);
 
-  it("tall viewport never auto-loads past the initial page (KNOWN BUG #242)", async () => {
-    // KNOWN BUG #242: when the initial page of items all fit within the viewport
-    // (no vertical overflow), IonInfiniteScroll's onIonInfinite never fires from
-    // scrolling, so songs past the first page are unreachable by scrolling alone.
-    // We use a very tall viewport (4000px) so all 30 initial cards fit with no
-    // overflow, then attempt to scroll and assert the list is STUCK at 30 —
-    // documenting the current (buggy) behavior. When #242 is fixed (auto-load
-    // until overflow, or a manual "load more"), this expectation should change to
-    // assert that more than 30 load.
+  it("tall viewport auto-loads past the initial page until content fills (#242)", async () => {
+    // FIXED #242: when the initial page of items all fit within the viewport (no
+    // vertical overflow), IonInfiniteScroll's onIonInfinite never fires from
+    // scrolling. SearchView now auto-loads additional pages until the list
+    // overflows the viewport (or all songs are loaded), and also exposes a
+    // "Load more songs" fallback button. We use a very tall viewport (4000px) so
+    // all 30 initial cards fit with no overflow, then assert that more than the
+    // initial 30 cards are reachable without any manual scrolling.
     const page = await browser.newPage();
     try {
       await page.setViewport({ width: 1366, height: 4000 });
       await page.goto(bookUrl(bookId), { waitUntil: "domcontentloaded" });
       await page.waitForSelector(selectors.searchViewIonCard, { timeout: 15000 });
-      const initial = await page.$$(selectors.searchViewIonCard);
-      expect(initial.length).toBe(30);
-      // Attempt to scroll: content fits, so nothing new should load.
-      await page.mouse.move(683, 2000);
-      for (let k = 0; k < 8; k++) {
-        await page.mouse.wheel({ deltaY: 1000 });
-        await delay(80);
-      }
-      await delay(1500);
+      const total = (songLists[bookId] as Song[]).length;
+      const expected = Math.min(total, 31); // at least one page beyond the initial 30
+      // Auto-load runs on a short timer after each render; poll until it settles.
+      await page.waitForFunction(
+        (sel, want) => document.querySelectorAll(sel).length >= want,
+        { timeout: 15000 },
+        selectors.searchViewIonCard,
+        expected
+      );
       const after = await page.$$(selectors.searchViewIonCard);
-      expect(after.length).toBe(30); // KNOWN BUG #242 — stuck at the initial page
+      // No manual scroll performed; auto-load alone got us past the first page.
+      expect(after.length).toBeGreaterThan(30);
     } finally {
       await page.close();
     }


### PR DESCRIPTION
## Bug (#242)

On viewports tall enough to fit all of the initial song-list items without any vertical overflow (desktop, very tall windows), infinite scroll never triggered. `IonInfiniteScroll`'s `onIonInfinite` only fires when the user can actually scroll the content; with no overflow there's nothing to scroll, so the remaining songs past the first page were unreachable. Affects both books, desktop only.

## Fix

In `src/components/SearchView.tsx`:

- **Auto-load until overflow.** After every render, a `useEffect` measures the nearest Ionic scroll container (`ion-content .inner-scroll`, falling back to the document element). If the list is **not** overflowing and songs remain, it loads the next page (10) and repeats — re-running on each `songCards` change — until the content overflows the viewport or all songs are loaded. This re-arms the normal infinite-scroll path once there's something to scroll.
- **Explicit "Load more songs" fallback button.** Rendered while songs remain, so even if the scroll trigger has nothing to observe (or auto-measure is flaky in some embedded webview), the user always has a manual way forward (`#loadMoreSongsButton`).
- Tracks an `allLoaded` flag so the infinite scroll is `disabled`, the effect stops probing, and the fallback button hides once the list is exhausted.

Initial page size (30) and the per-page increment (10) are unchanged, so the existing "initial render shows 30 cards" behavior on the standard desktop viewport (which already overflows) is preserved.

## Test update

`Layer2.features.test.tsx` had a `#242` test that asserted the **buggy** behavior ("tall viewport never auto-loads past the initial page… stuck at 30"). It's been updated to assert the **fixed** behavior: on a 4000px-tall viewport, more than the initial 30 cards become reachable **without any manual scrolling** (polls via `waitForFunction`). Renamed to "tall viewport auto-loads past the initial page until content fills (#242)".

Verified locally with `CI=true npm run build` (clean). CI runs the full e2e suite.

Fixes #242