### PR TITLE
ci: stop PR-comment step failing the APK check

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -131,6 +131,7 @@ jobs:
 
       - name: Add Comment on PR
         uses: mshick/add-pr-comment@v1
+        continue-on-error: true
         with:
           message: Android APK for this PR has been built and uploaded. Check Github Actions.
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem
The required **Build Android APK** check goes red on PRs that run with a read-only `GITHUB_TOKEN` (notably every Dependabot PR). The APK builds and uploads successfully — the only failing step is the final cosmetic **Add Comment on PR** (`mshick/add-pr-comment`), which needs write scope and dies with `Resource not accessible by integration`.

This blocks merging otherwise-safe PRs, since master protection requires the APK check to pass.

## Fix
Mark the comment step `continue-on-error: true` so a failure there can no longer fail the job. No special-casing of any actor — the step still runs, it just cannot red the required check.

Applies to all PRs, not just Dependabot.